### PR TITLE
fix: crash caused when searching for integrated weapon

### DIFF
--- a/src/data/lancer/lcp/homebrew/liminal-space/frames.json
+++ b/src/data/lancer/lcp/homebrew/liminal-space/frames.json
@@ -537,8 +537,8 @@
       "activation": "Full",
       "active_effect": "Make an attack with All The Guns. This is the only way this weapon can be fired.",
       "integrated": [
-        "liminal_downfall_wrath_aggression",
-        "liminal_downfall_wrath_alltheguns"
+        "liminal_downfall_wrath_aggression_integrated",
+        "liminal_downfall_wrath_alltheguns_integrated"
       ]
     }
   },
@@ -719,8 +719,8 @@
       ],
       "description": "To call the Goetia a weapon would be to decidedly undersell it. This horrifying device is a fragmentary extrusion of a powerful paracausal entity that Magnum Opus has listed as the Belial-class: a being that perceives a world of flame and torment that reality has no power to dispute or assuage.<br><br>The first knowledge of Belial came from the Voladore traders that often work with Magnum Opus, both a gift and a warning. Ships had been going missing along one of the blink gate lines and Magnum Opus was part of a UIB/USB investigation into possible sabotage. The sealing of the Entity exacted a high price not only in lives but in the loss of the original Agartha Blink Station, sunk into the event horizon of a black hole as its gate warped and shifted, claws stretching the gate wide.<br><br>While purged from records by the UIB, the Agartha Blink Station still can be called with emergency codes stored within the Solomon, if one is sure they can put down what they call up. The chains of hereticode around the shards of Belial hold. For now, at least.",
       "integrated": [
-        "liminalspace_moi_solomon_infernalstrength",
-        "liminalspace_moi_solomon_goetia"
+        "liminalspace_moi_solomon_infernalstrength_integrated",
+        "liminalspace_moi_solomon_goetia_integrated"
       ]
     }
   },

--- a/src/data/lancer/lcp/homebrew/liminal-space/weapons.json
+++ b/src/data/lancer/lcp/homebrew/liminal-space/weapons.json
@@ -491,7 +491,7 @@
     "description": "The signature weapon of the SLOTH frame is hideously simple in design - literally just an enormous slab of exceedingly dense material, made with the frame’s immense strength in mind. The two together form a force that rightly terrifies enemy actors; to be caught close to a hostile SLOTH is to suddenly cease existing. In other hands, it is still an enormous pile of painful physics lessons."
   },
   {
-    "id": "liminal_downfall_wrath_aggression",
+    "id": "liminal_downfall_wrath_aggression_integrated",
     "name": "Aggression",
     "mount": "Main",
     "type": "CQB",
@@ -514,7 +514,7 @@
     "effect": "This weapon gains the AP tag against characters you have previously attacked this round."
   },
   {
-    "id": "liminal_downfall_wrath_alltheguns",
+    "id": "liminal_downfall_wrath_alltheguns_integrated",
     "name": "All The Guns",
     "mount": "Main",
     "type": "???",
@@ -665,7 +665,7 @@
     "description": "The downfall of many who think that Magnum Opus designs are flash without substance, this unobtrusive rod is in fact a very potent launch weapon for small near-critical implosion charges. The scorching shockwaves from these charges provide all the expected flash, while the crushing impact sends warmachines tumbling."
   },
   {
-    "id": "liminalspace_moi_solomon_goetia",
+    "id": "liminalspace_moi_solomon_goetia_integrated",
     "name": "Goetia",
     "mount": "Heavy",
     "type": "Nexus",
@@ -694,7 +694,7 @@
     "description": ""
   },
   {
-    "id": "liminalspace_moi_solomon_infernalstrength",
+    "id": "liminalspace_moi_solomon_infernalstrength_integrated",
     "name": "Infernal Strength",
     "mount": "Heavy",
     "type": "Melee",


### PR DESCRIPTION
properly mark integrated weapons ids as being integrated